### PR TITLE
Cambiar la ventana de mensaje por una interface grafica con wx

### DIFF
--- a/addon/globalPlugins/DLEChecker/__init__.py
+++ b/addon/globalPlugins/DLEChecker/__init__.py
@@ -3,6 +3,9 @@
 #See the file COPYING.txt for more details.
 #Copyright (C) 2020 Antonio Cascales <antonio.cascales@gmail.com> and Jose Manuel Delicado <jm.delicado@nvda.es>
 
+import wx
+import gui
+
 import globalPluginHandler
 import ui
 import api
@@ -32,7 +35,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			else:
 				selectedText = info.text.lower()
 		else:
-			selectedText = obj.selection.text
+			selectedText = obj.selection.text.lower()
 			
 			if obj.selection.text == "":
 				ui.message(_("Selecciona un texto primero."))
@@ -54,6 +57,74 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				if hasattr(i, 'text'):
 					message = _(message + i.text + "\n")
 			
-			ui.browseableMessage(message)
+#			ui.browseableMessage(message)
+			self.ventanaMSG = DialogoMsg(gui.mainFrame, "DLEChecker", message)
+			gui.mainFrame.prePopup()
+			self.ventanaMSG.Show()
 		except:
 			ui.message(_("Error al intentar obtener la definición de la palabra."))
+
+class DialogoMsg(wx.Dialog):
+# Function taken from the add-on emoticons to center the window
+	def _calculatePosition(self, width, height):
+		w = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_X)
+		h = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_Y)
+		# Centre of the screen
+		x = w / 2
+		y = h / 2
+		# Minus application offset
+		x -= (width / 2)
+		y -= (height / 2)
+		return (x, y)
+
+	def __init__(self, parent, titulo, mensaje):
+		WIDTH = 800
+		HEIGHT = 600
+		pos = self._calculatePosition(WIDTH, HEIGHT)
+
+		super(DialogoMsg, self).__init__(parent, -1, title=titulo, pos = pos, size = (WIDTH, HEIGHT))
+
+		self.mensaje = mensaje
+
+		panel_dialogo = wx.Panel(self)
+
+		principalBox = wx.BoxSizer(wx.VERTICAL)
+		verticalBox = wx.BoxSizer(wx.VERTICAL)
+		horizontalBox = wx.BoxSizer(wx.HORIZONTAL)
+
+		etiqueta = wx.StaticText(panel_dialogo, wx.ID_ANY, label="Resultado:")
+		textoResultado = wx.TextCtrl(panel_dialogo, wx.ID_ANY, style = wx.TE_MULTILINE|wx.TE_READONLY|wx.HSCROLL) 
+
+		verticalBox.Add(etiqueta, 0, wx.EXPAND)
+		verticalBox.Add(textoResultado, 1, wx.EXPAND | wx.ALL)
+
+		self.leerBTN = wx.Button(panel_dialogo, wx.ID_ANY, "Leer resultado")
+		self.copiarBTN = wx.Button(panel_dialogo, wx.ID_ANY, "Copiar al portapapeles")
+		self.salirBTN = wx.Button(panel_dialogo, wx.ID_CANCEL, "&Salir")
+
+		horizontalBox.Add(self.leerBTN, 0, wx.CENTER)
+		horizontalBox.Add(self.copiarBTN, 0, wx.CENTER)
+		horizontalBox.Add(self.salirBTN, 0, wx.CENTER)
+
+		principalBox.Add(verticalBox, 1, wx.EXPAND | wx.ALL)
+		principalBox.Add(horizontalBox, 0, wx.CENTER)
+
+		panel_dialogo.SetSizer(principalBox)
+
+		self.Bind(wx.EVT_BUTTON, self.onLeer, self.leerBTN)
+		self.Bind(wx.EVT_BUTTON, self.onCopiar, self.copiarBTN)
+		self.Bind(wx.EVT_BUTTON, self.onSalir, id=wx.ID_CANCEL)
+
+		textoResultado.WriteText(self.mensaje)
+		textoResultado.SetInsertionPoint(0) 
+
+	def onLeer(self, event):
+		ui.message(self.mensaje)
+
+	def onCopiar(self, event):
+		api.copyToClip(self.mensaje)
+		ui.message("Copiado al portapapeles")
+
+	def onSalir(self, event):
+		self.Destroy()
+		gui.mainFrame.postPopup()


### PR DESCRIPTION
Sustituido mensaje virtual por una interface grafica con wx.

Dicha interface contiene 3 botones que permitirá leer el resultado obtenido, pegarlo al portapapeles y salir.

También se puede salir presionando Escape.

En el cuadro de texto de solo lectura también podemos copiar y seleccionar todo con botón aplicaciones.
