### PR TITLE
No ignorar guiones

### DIFF
--- a/addon/globalPlugins/DLEChecker/__init__.py
+++ b/addon/globalPlugins/DLEChecker/__init__.py
@@ -265,7 +265,7 @@ class Hilo(Thread):
 		cadenaResultante = ""
 		
 		for caracter in texto:
-			if ( caracter in string.ascii_lowercase + string.ascii_uppercase + 'áéíóúüñ ' ):
+			if ( caracter in string.ascii_lowercase + string.ascii_uppercase + 'áéíóúüñ -' ):
 				cadenaResultante += caracter
 		
 		return cadenaResultante


### PR DESCRIPTION
Los términos con guion (prefijos y sufijos) también están incluidos en el diccionario.

(Por ejemplo, intenta buscar meteorito, y luego buscar -ito, como marca antes de la definición, tanto en el complemento como en la web).