### PR TITLE
Quitar el BOM del manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# DLEChecker
+# DLEChecker
 
 ## Buscador de definiciones en el Diccionario de la Lengua Española.
 


### PR DESCRIPTION
Seguramente por editar este archivo con el bloc de notas, al principio se le inserta un carácter que hace que al convertirlo a html y verlo en un navegador el primer encabezado no se muestre como tal.