### PR TITLE
Poner la palabra buscada en minúsculas incluso en el cuadro de búsqueda

### DIFF
--- a/addon/globalPlugins/DLEChecker/__init__.py
+++ b/addon/globalPlugins/DLEChecker/__init__.py
@@ -164,7 +164,7 @@ class NuevaConsulta(wx.Dialog):
 		self.Show()
 	
 	def onAceptar(self, e):
-		terminoABuscar = self.cuadroEdicion.GetValue()
+		terminoABuscar = self.cuadroEdicion.GetValue().lower()
 		if terminoABuscar != "":
 			self.Close()
 			hilo = Hilo(terminoABuscar)
@@ -265,7 +265,7 @@ class Hilo(Thread):
 		cadenaResultante = ""
 		
 		for caracter in texto:
-			if ( caracter in string.ascii_lowercase + string.ascii_uppercase + 'áéíóúüñ -' ):
+			if ( caracter in string.ascii_lowercase + 'áéíóúüñ -' ):
 				cadenaResultante += caracter
 		
 		return cadenaResultante


### PR DESCRIPTION
Esto permite buscar palabras con tilde incluso cuando el bloqueo de mayúsculas está activado.
Ya que se hace cuando se selecciona texto, de paso, aquí también.